### PR TITLE
fix ValueError: max() arg is an empty sequence

### DIFF
--- a/src/tox/session/commands/show_env.py
+++ b/src/tox/session/commands/show_env.py
@@ -11,7 +11,7 @@ def show_envs(config, all_envs=False, description=False):
 
     if description and default:
         report.line("default environments:")
-    max_length = max(len(env) for env in (default + extra))
+    max_length = max(len(env) for env in (default + extra) or [''])
 
     def report_env(e):
         if description:


### PR DESCRIPTION
Closes #1343.

When running `tox -l` with a tox.ini file not containing any default environments, instead of an empty output, an exception is raised:

```
$ tox -l
tox -l
Traceback (most recent call last):
  File "/Users/jq/.pyenv/versions/py38/bin/tox", line 8, in <module>
    sys.exit(cmdline())
  File "/Users/jq/.pyenv/versions/3.8.1/envs/py38/lib/python3.8/site-packages/tox/session/__init__.py", line 44, in cmdline
    main(args)
  File "/Users/jq/.pyenv/versions/3.8.1/envs/py38/lib/python3.8/site-packages/tox/session/__init__.py", line 68, in main
    exit_code = session.runcommand()
  File "/Users/jq/.pyenv/versions/3.8.1/envs/py38/lib/python3.8/site-packages/tox/session/__init__.py", line 189, in runcommand
    self.showenvs(all_envs=False, description=show_description)
  File "/Users/jq/.pyenv/versions/3.8.1/envs/py38/lib/python3.8/site-packages/tox/session/__init__.py", line 293, in showenvs
    show_envs(self.config, all_envs=all_envs, description=description)
  File "/Users/jq/.pyenv/versions/3.8.1/envs/py38/lib/python3.8/site-packages/tox/session/commands/show_env.py", line 14, in show_envs
    max_length = max((len(env) for env in (default + extra)))
ValueError: max() arg is an empty sequence
```